### PR TITLE
feat: add kustomization.yaml files across apps and infrastructure

### DIFF
--- a/apps/homelab/asustor/kustomization.yaml
+++ b/apps/homelab/asustor/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ./asustor-ingress.yaml
+  - ./asustor.yaml

--- a/apps/homelab/development/kustomization.yaml
+++ b/apps/homelab/development/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ./brandon-dev-namespace.yaml
+  - ./harbor-regcred.yaml

--- a/apps/homelab/haproxy/kustomization.yaml
+++ b/apps/homelab/haproxy/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ./haproxy-ingress.yaml
+  - ./haproxy.yaml

--- a/apps/homelab/harbor/kustomization.yaml
+++ b/apps/homelab/harbor/kustomization.yaml
@@ -1,0 +1,10 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ./harbor-admin-secret.yaml
+  - ./harbor-db-secret.yaml
+  - ./harbor-helm.yaml
+  - ./harbor-namespace.yaml
+  - ./harbor-repo.yaml
+  - ./harbor-secrets.yaml

--- a/apps/homelab/home-hud/kustomization.yaml
+++ b/apps/homelab/home-hud/kustomization.yaml
@@ -1,0 +1,11 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ./harbor-regcred.yaml
+  - ./home-hud-ns.yaml
+  - ./pi-led-api-deploy.yaml
+  - ./pi-led-api-image-policy.yaml
+  - ./pi-led-api-image-repo.yaml
+  - ./pi-led-api-ingress.yaml
+  - ./pi-led-api-svc.yaml

--- a/apps/homelab/kustomization.yaml
+++ b/apps/homelab/kustomization.yaml
@@ -1,0 +1,15 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ./arc
+  - ./asustor
+  - ./dashy
+  - ./development
+  - ./haproxy
+  - ./harbor
+  - ./home-hud
+  - ./pihole
+  - ./podinfo
+  - ./proxmox
+  - ./verdaccio

--- a/apps/homelab/pihole/kustomization.yaml
+++ b/apps/homelab/pihole/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ./pihole-ingress-admin-redirect.yaml
+  - ./pihole-ingress.yaml
+  - ./pihole.yaml

--- a/apps/homelab/podinfo/kustomization.yaml
+++ b/apps/homelab/podinfo/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ./podinfo-internal-ingress.yaml
+  - ./podinfo-kustomization.yaml
+  - ./podinfo-source.yaml

--- a/apps/homelab/proxmox/kustomization.yaml
+++ b/apps/homelab/proxmox/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ./proxmox-ingress.yaml
+  - ./proxmox.yaml

--- a/apps/homelab/verdaccio/kustomization.yaml
+++ b/apps/homelab/verdaccio/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ./verdaccio-helm.yaml
+  - ./verdaccio-ingress.yaml
+  - ./verdaccio-repo.yaml

--- a/infrastructure/base/cert-manager/kustomization.yaml
+++ b/infrastructure/base/cert-manager/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ./cert-manager-cloudflare-secret.yaml
+  - ./cert-manager-helm-release.yaml
+  - ./cert-manager-helm-repo.yaml
+  - ./cert-manager-namespace.yaml

--- a/infrastructure/base/kustomization.yaml
+++ b/infrastructure/base/kustomization.yaml
@@ -1,0 +1,13 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ./cert-manager
+  - ./grafana
+  - ./longhorn-system
+  - ./monitoring
+  - ./nas-storage
+  - ./bitnami-helm-repo.yaml
+  - ./patch-core-dns-configmap.yaml
+  - ./sealed-secrets-helm-release.yaml
+  - ./sealed-secrets-helm-repo.yaml

--- a/infrastructure/base/longhorn-system/kustomization.yaml
+++ b/infrastructure/base/longhorn-system/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ./longhorn-cifs-secret.yml
+  - ./longhorn-helm-release.yaml
+  - ./longhorn-helm-repo.yaml
+  - ./longhorn-namespace.yaml

--- a/infrastructure/base/monitoring/kustomization.yaml
+++ b/infrastructure/base/monitoring/kustomization.yaml
@@ -1,0 +1,10 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ./loki-helm-release.yaml
+  - ./monitoring-helm-release.yaml
+  - ./monitoring-helm-repo.yaml
+  - ./monitoring-namespace.yaml
+  - ./otc-helm-release.yaml
+  - ./otc-helm-repo.yaml

--- a/infrastructure/base/nas-storage/kustomization.yaml
+++ b/infrastructure/base/nas-storage/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ./storage-helm-release.yaml
+  - ./storage-helm-repo.yaml
+  - ./storage-namespace.yaml

--- a/infrastructure/config/grafana/kustomization.yaml
+++ b/infrastructure/config/grafana/kustomization.yaml
@@ -1,6 +1,6 @@
 resources:
-  - ./grafana.yaml
+  - ./dashboard-my-hosts-configmap.yaml
   - ./grafana-staging-pvc.yaml
   - ./grafana-staging.yaml
-  - ./dashboard-my-hosts-configmap.yaml
+  - ./grafana.yaml
   # - ./prometheus-grafana-datasource.yaml

--- a/infrastructure/config/kustomization.yaml
+++ b/infrastructure/config/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ./grafana
+  - ./cloudflare-ddns.yaml
+  - ./cluster-issuers.yaml
+  - ./longhorn-backups.yaml

--- a/infrastructure/controllers/1password/kustomization.yaml
+++ b/infrastructure/controllers/1password/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ./op-connect-helm-release.yaml
+  - ./op-connect-helm-repo.yaml
+  - ./op-connect-namespace.yaml
+  - ./op-credentials.yaml

--- a/infrastructure/controllers/external-dns/kustomization.yaml
+++ b/infrastructure/controllers/external-dns/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ./external-dns-cloudflare-secret.yaml
+  - ./external-dns-helm-release.yaml
+  - ./external-dns-namespace.yaml

--- a/infrastructure/controllers/ingress-nginx/kustomization.yaml
+++ b/infrastructure/controllers/ingress-nginx/kustomization.yaml
@@ -1,0 +1,9 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ./ingress-nginx-helm-chart.yaml
+  - ./ingress-nginx-helm-release.yaml
+  - ./ingress-nginx-helm-repo.yaml
+  - ./ingress-nginx-ns.yaml
+  - ./ingress-nginx-service-monitor.yaml

--- a/infrastructure/controllers/kustomization.yaml
+++ b/infrastructure/controllers/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ./1password
+  - ./external-dns
+  - ./ingress-nginx


### PR DESCRIPTION
This PR adds kustomization.yaml files to organize Kubernetes resources using Kustomize.

## Changes
- Add kustomization.yaml to apps/homelab and all subdirectories
- Add kustomization.yaml to infrastructure/base and all subdirectories  
- Add kustomization.yaml to infrastructure/config
- Add kustomization.yaml to infrastructure/controllers and all subdirectories

This enables proper Kustomize resource management and organization across the entire repository structure.